### PR TITLE
Correção de bug na tela de login que mantém botão "Entrar" inativo mesmo com o preenchimento da senha

### DIFF
--- a/src/Susep.SISRH.WebApp/ClientApp/src/app/shared/components/login/login.component.html
+++ b/src/Susep.SISRH.WebApp/ClientApp/src/app/shared/components/login/login.component.html
@@ -12,7 +12,7 @@
             <div class="col-12">
               <!-- Área de preenchimento do usuário -->
               <section class="br-form">
-                <form [formGroup]="form">
+                <form [formGroup]="form" (ngSubmit)="logar()">
 
                   <!-- Informar login -->
                   <div class="field">
@@ -24,7 +24,7 @@
                   <!-- Informar a senha -->
                   <div class="field">
                     <field-validation [classList]="['br-input', 'is-action']" errorMessage="Campo obrigatório." label="Senha">
-                      <input id="password" type={{passwordType}} #password placeholder="Digite sua senha" name="password" formControlName="password">
+                      <input id="password" type={{passwordType}} #password placeholder="Digite sua senha" name="password" formControlName="password" (keydown.enter)="onPressEnter()">
                       <a class="action" id="showPassword" href="javascript:void(0);" (click)="toggleMostrarPassword()">
                         <span class="sr-only">Mostrar senha</span>
                         <i class="fas fa-eye"></i>
@@ -36,7 +36,7 @@
 
                   <!-- Botões de ação -->
                   <div class="actions justify-content-center">
-                    <button class="button is-primary" name="button" value="login" [disabled]="!form.valid" (click)="logar()">Entrar</button>
+                    <button class="button is-primary" name="button" value="login" [disabled]="!form.valid">Entrar</button>
                   </div>
                 </form>
               </section>

--- a/src/Susep.SISRH.WebApp/ClientApp/src/app/shared/components/login/login.component.ts
+++ b/src/Susep.SISRH.WebApp/ClientApp/src/app/shared/components/login/login.component.ts
@@ -25,7 +25,7 @@ export class LoginComponent implements OnInit {
     this.form = this.formBuilder.group({
       username: ['', [Validators.required]],
       password: ['', [Validators.required]]
-    }, { updateOn: 'blur' });
+    }, { updateOn: 'change' });
   }
 
   toggleMostrarPassword() {
@@ -50,5 +50,9 @@ export class LoginComponent implements OnInit {
   keyup() {
     this.form.get('username').updateValueAndValidity();
     this.form.get('password').updateValueAndValidity();
+  }
+  
+  onPressEnter() {
+    this.form.markAllAsTouched();
   }
 }


### PR DESCRIPTION
Correção do bug que impacta na usabilidade do sistema na tela de login. Atualmente o sistema exige duplo clique no botão Entrar, visto que o botão só é ativado ao disparar o blur da senha. 

A solução enviada realiza a validação do formulário durante o preenchimento da senha, permitindo uso de enter e retira a necessidade de duplo clique no Entrar, necessitando de apenas um clique.

Para evitar a exception ExpressionChangedAfterItHasBeenCheckedError ao logar por meio do enter, criou-se um método que mapeia o pseudo-evento de pressionamento do enter e realiza a marcação dos componentes do formulário. Isso evita um problema no ciclo de vida dos hooks do angular